### PR TITLE
Feature/esm tools dir class

### DIFF
--- a/esm_rcfile/esm_rcfile.py
+++ b/esm_rcfile/esm_rcfile.py
@@ -47,12 +47,36 @@ API Documentation
 -----------------
 """
 import os
+import esm_tools
 
 rcfile = os.path.expanduser("~") + "/.esmtoolsrc"
 
 
 class EsmRcfileError(Exception):
     pass
+
+
+class EsmToolsDir(str):
+
+    def __init__(self, path_type):
+        self.path_type = path_type
+
+    def __str__(self):
+        return self.find_path()
+
+    def __add__(self, add_string):
+        return self.find_path() + add_string
+
+    def find_path(self):
+
+        if self.path_type=="FUNCTION_PATH":
+            return esm_tools.get_config_filepath("") + "/"
+        elif self.path_type=="NAMELIST_PATH":
+            return esm_tools.get_namelist_filepath("") + "/"
+        elif self.path_type=="RUNSCRIPT_PATH":
+            return esm_tools.get_runscript_filepath("") + "/"
+        else:
+            raise Exception("Incorrect path type!")
 
 
 def set_rc_entry(key, value):

--- a/esm_rcfile/esm_rcfile.py
+++ b/esm_rcfile/esm_rcfile.py
@@ -57,18 +57,74 @@ class EsmRcfileError(Exception):
 
 
 class EsmToolsDir(str):
+    """
+    A string subclass whose instances provide the paths to `esm_tools` folders
+    (`configs`, `namelists` and `runscripts`) when evaluated as a string (i.e.
+    `str(<your_instance>)` or `<your_instance> + <a_string>`).
+
+    This class is thought as a generalised solution for the problem of removing the
+    `FUNCTION_PATH`, `NAMELIST_PATH` and `RUNSCRIPT_PATH` from the `.esmtoolsrc` file,
+    and intends to provide those paths correctly, both for virtual environment and open
+    runs, right at the time where the variable containing the instance is evaluated
+    by the `esm_parser`, as a string.
+
+    This should solve issues with, for example, preprocessing and postprocessing scripts
+    called during runtime with a `NONE_YET/<path_to_the_script>`.
+    """
 
     def __init__(self, path_type):
+        """
+        Initializes the instance. To do that, use `<your_instance_name> =
+        EsmToolsDir(<path_type>)` where `path_type` can be::
+          - "FUNCTION_PATH"
+          - "NAMELIST_PATH"
+          - "RUNSCRIPT_PATH"
+
+        Parameters
+        ----------
+        path_type : str
+            ESM-Tools path type to be loaded by the object.
+        """
         self.path_type = path_type
 
     def __str__(self):
+        """
+        When the instance is evaluated as a string, it returns the correct path to its
+        corresponding `esm_tools` folder.
+
+        Returns
+        -------
+        <esm_tools_folder_type_PATH> : str
+            The path to the required folder.
+        """
         return self.find_path()
 
     def __add__(self, add_string):
+        """
+        When the instance is used together with a sum operation, it returns the correct
+        path to its corresponding `esm_tools` folder, plus the operation input.
+
+        Parameters
+        ----------
+        add_string : str
+            String to be added to the path.
+
+        Returns
+        -------
+        <PATH+add_string> : str
+            The path to the required folder plus the string that follows (`add_string`).
+        """
         return self.find_path() + add_string
 
     def find_path(self):
+        """
+        This method returns the path of the `esm_tools` folder required.
 
+        Returns
+        -------
+        <esm_tools_folder_type_PATH> : str
+            The path to the required folder.
+        """
         if self.path_type=="FUNCTION_PATH":
             return esm_tools.get_config_filepath("") + "/"
         elif self.path_type=="NAMELIST_PATH":


### PR DESCRIPTION
A string subclass whose instances provide the paths to `esm_tools` folders  (`configs`, `namelists` and `runscripts`) when evaluated as a string (i.e. `str(<your_instance>)` or `<your_instance> + <a_string>`).

This class is thought as a generalised solution for the problem of removing the `FUNCTION_PATH`, `NAMELIST_PATH` and `RUNSCRIPT_PATH` from the `.esmtoolsrc` file, and intends to provide those paths correctly, both for virtual environment and open runs, right at the time where the variable containing the instance is evaluated by the `esm_parser`, as a string.

This should solve issues with, for example, preprocessing and postprocessing scripts called during runtime with a `NONE_YET/<path_to_the_script>`.

**Requires**
- esm-tools/esm_tools#279